### PR TITLE
update close message to include user/repo

### DIFF
--- a/pulley.js
+++ b/pulley.js
@@ -221,7 +221,7 @@
 
 		callAPI( path, function( data ) {
 			var match,
-				msg = "Close GH-" + id + ": " + pull.title + ".",
+				msg = "Close " + user_repo + "#" + id + ": " + pull.title + ".",
 				author = JSON.parse( data )[ 0 ].commit.author.name,
 				base_branch = pull.base.ref,
 				issues = [],


### PR DESCRIPTION
will now look like "Close ottemo/urbanity#32: " which still works with github, but doesn't confuse forked repos when you merge upstream.
